### PR TITLE
Hide table of contents from package-list

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -99,6 +99,18 @@ defaults:
       author_profile: false
       show_date: false
 
+  # Linux Package List (hide toc)
+  - scope:
+      path: "_posts/2021-12-04-linux-package-list.md"
+      type: posts
+    values:
+      layout: single
+      author_profile: false
+      comments: true
+      show_date: false
+      toc: false
+      toc_sticky: false
+
 category_archive:
   type: liquid
   path: /categories/

--- a/_config.yml
+++ b/_config.yml
@@ -99,18 +99,6 @@ defaults:
       author_profile: false
       show_date: false
 
-  # Linux Package List (hide toc)
-  - scope:
-      path: "_posts/2021-12-04-linux-package-list.md"
-      type: posts
-    values:
-      layout: single
-      author_profile: false
-      comments: true
-      show_date: false
-      toc: false
-      toc_sticky: false
-
 category_archive:
   type: liquid
   path: /categories/

--- a/_posts/2021-12-04-linux-package-list.md
+++ b/_posts/2021-12-04-linux-package-list.md
@@ -4,6 +4,7 @@ categories:
   - Linux
 tags:
   - Linux
+toc: false
 ---
 
 Brainux では、debootstrap で生成した rootfs に加えて以下のパッケージをインストールしています。


### PR DESCRIPTION
# 軽微な変更点

- セクション名をつけていないので、空の目次が表示されるが、見栄えが悪いため隠したかった

【変更前】
![image](https://user-images.githubusercontent.com/58127312/176984539-fbd7a865-bb97-4bca-9e44-7aaa4fffff3a.png)
【変更後】
![image](https://user-images.githubusercontent.com/58127312/176984644-39641bb9-ef0b-4ddb-8b02-0962cbfe398e.png)

他のページでは問題なく目次が表示される。
![image](https://user-images.githubusercontent.com/58127312/176984668-6094173d-34ba-4f3d-801b-d0ef9ba186ab.png)
