### PR TITLE
Ethernet Gadget についての記述のアップデート

### DIFF
--- a/collections/_beginners/get-started.md
+++ b/collections/_beginners/get-started.md
@@ -27,23 +27,18 @@ Linux ディストリビューションは、カーネルとそれ以外のソ�
 
 内蔵ハードウェアの対応状況や使い方については[内蔵ハードウェア](#内蔵ハードウェア)をご覧ください。キーマップもそちらに掲載しています。
 
-|機種  |Linux 起動        |キーボード        |注釈|
+|機種  |Linux 起動        |キーボード        |DTBファイル名|
 |:-----|:----------------:|:----------------:|:---|
 |PW-ACxxx, GCxxx, TC980||||
 |PW-G4000, G5000, G5100, A7000, A9000||||
-|PW-G4200, G5200 ~ 5300, A7200 ~ 7400, A9100 ~ 9300|:white_check_mark:|:white_check_mark:||
-|GX500, GX300|:white_check_mark:|:white_check_mark:|画面が非常に暗くなる|
-|PW-Sx1|:white_check_mark:|:white_check_mark:||
-|PW-Sx2|:white_check_mark:|:white_check_mark:||
-|PW-Sx3|:white_check_mark:|:white_check_mark:||
-|PW-Sx4|:white_check_mark:|:white_check_mark:||
-|PW-Sx5|:white_check_mark:|:white_check_mark:||
-|PW-Sx6|:white_check_mark:|:white_check_mark:||
-|PW-Sx7|:white_check_mark:|:white_check_mark:||
-|PW-HC4 ~ 6, H7700 ~ H9100|:white_check_mark:|:white_check_mark:||
-|PW-SR1 ~ 3|:white_check_mark:|:white_check_mark:||
-|PW-AA1 ~ 2|:white_check_mark:|:white_check_mark:||
-|PW-AJ1 ~ 2|:white_check_mark:|:white_check_mark:||
+|PW-G4200, G5200 ~ 5300, A7200 ~ 7400, A9100 ~ 9300, GX500, GX300|:white_check_mark:|:white_check_mark:|imx28-pwa7200.dtb|
+|PW-Sx1, HC4, SR1|:white_check_mark:|:white_check_mark:|imx28-pwsh1.dtb|
+|PW-Sx2, HC5|:white_check_mark:|:white_check_mark:|imx28-pwsh2.dtb|
+|PW-Sx3, HC6|:white_check_mark:|:white_check_mark:|imx28-pwsh3.dtb|
+|PW-Sx4, H7700, SR2|:white_check_mark:|:white_check_mark:|imx28-pwsh4.dtb|
+|PW-Sx5, H7800, AA1, AJ1|:white_check_mark:|:white_check_mark:|imx28-pwsh5.dtb|
+|PW-Sx6, H8000, AA2, AJ2|:white_check_mark:|:white_check_mark:|imx28-pwsh6.dtb|
+|PW-Sx7, H8100, H9100, SR3|:white_check_mark:|:white_check_mark:|imx28-pwsh7.dtb|
 |PW-x1, x2, ESxxxx, SR4||||
 
 

--- a/collections/_beginners/get-started.md
+++ b/collections/_beginners/get-started.md
@@ -27,18 +27,18 @@ Linux ディストリビューションは、カーネルとそれ以外のソ�
 
 内蔵ハードウェアの対応状況や使い方については[内蔵ハードウェア](#内蔵ハードウェア)をご覧ください。キーマップもそちらに掲載しています。
 
-|機種  |Linux 起動        |キーボード        |DTBファイル名|
+|機種  |Linux 起動        |キーボード        |デバイスツリー名|
 |:-----|:----------------:|:----------------:|:---|
 |PW-ACxxx, GCxxx, TC980||||
 |PW-G4000, G5000, G5100, A7000, A9000||||
-|PW-G4200, G5200 ~ 5300, A7200 ~ 7400, A9100 ~ 9300, GX500, GX300|:white_check_mark:|:white_check_mark:|imx28-pwa7200.dtb|
-|PW-Sx1, HC4, SR1|:white_check_mark:|:white_check_mark:|imx28-pwsh1.dtb|
-|PW-Sx2, HC5|:white_check_mark:|:white_check_mark:|imx28-pwsh2.dtb|
-|PW-Sx3, HC6|:white_check_mark:|:white_check_mark:|imx28-pwsh3.dtb|
-|PW-Sx4, H7700, SR2|:white_check_mark:|:white_check_mark:|imx28-pwsh4.dtb|
-|PW-Sx5, H7800, AA1, AJ1|:white_check_mark:|:white_check_mark:|imx28-pwsh5.dtb|
-|PW-Sx6, H8000, AA2, AJ2|:white_check_mark:|:white_check_mark:|imx28-pwsh6.dtb|
-|PW-Sx7, H8100, H9100, SR3|:white_check_mark:|:white_check_mark:|imx28-pwsh7.dtb|
+|PW-G4200, G5200 ~ 5300, A7200 ~ 7400, A9100 ~ 9300, GX500, GX300|:white_check_mark:|:white_check_mark:|imx28-pwa7200|
+|PW-Sx1, HC4, SR1|:white_check_mark:|:white_check_mark:|imx28-pwsh1|
+|PW-Sx2, HC5|:white_check_mark:|:white_check_mark:|imx28-pwsh2|
+|PW-Sx3, HC6|:white_check_mark:|:white_check_mark:|imx28-pwsh3|
+|PW-Sx4, H7700, SR2|:white_check_mark:|:white_check_mark:|imx28-pwsh4|
+|PW-Sx5, H7800, AA1, AJ1|:white_check_mark:|:white_check_mark:|imx28-pwsh5|
+|PW-Sx6, H8000, AA2, AJ2|:white_check_mark:|:white_check_mark:|imx28-pwsh6|
+|PW-Sx7, H8100, H9100, SR3|:white_check_mark:|:white_check_mark:|imx28-pwsh7|
 |PW-x1, x2, ESxxxx, SR4||||
 
 

--- a/collections/_tips/usb-ethernet-gadget.md
+++ b/collections/_tips/usb-ethernet-gadget.md
@@ -60,19 +60,22 @@ excerpt: PC と USB ケーブル1本で接続できる便利な仕組みとそ�
    書き換え後は以下のようになります。
 
    ```diff
-   ahb@80080000 {
-           usb0: usb@80080000 {
-                   pinctrl-names = "default";
-                   pinctrl-0 = <&usb0_id_pins_a>;
-                   vbus-supply = <&reg_usb0_vbus>;
-   -               dr_mode = "host";
-   +               dr_mode = "peripheral";
-                   status = "okay";
-           };
+   usb@80080000 {
+           compatible = "fsl,imx28-usb\0fsl,imx27-usb";
+           reg = < 0x80080000 0x10000 >;
+           interrupts = < 0x5d >;
+           clocks = < 0x03 0x3c >;
+           fsl,usbphy = < 0x1f >;
+           status = "okay";
+           pinctrl-names = "default";
+           pinctrl-0 = < 0x20 >;
+           vbus-supply = < 0x21 >;
+   -       dr_mode = "host";
+   +       dr_mode = "peripheral";
    };
    ```
 
-   書き換えられたら保存してエディタを終了します。`Ctrl+O`の次に`Enter`を押して保存して、`Ctrl+X`で終了します。
+   書き換えたら保存してエディタを終了します。`Ctrl+O`の次に`Enter`を押して保存して、`Ctrl+X`で終了します。
 
 5. 編集したものをバイナリ形式に変換します
 
@@ -156,7 +159,7 @@ sudo reboot
    次回起動時からはこのスクリプトを都度実行します。
 
    ```sh
-   ./gadget.sh
+   sudo ./gadget.sh
    ```
 
 

--- a/collections/_tips/usb-ethernet-gadget.md
+++ b/collections/_tips/usb-ethernet-gadget.md
@@ -21,11 +21,15 @@ excerpt: PC と USB ケーブル1本で接続できる便利な仕組みとそ�
 # USB コントローラの動作モードを変更する
 
 初期状態では Brain の USB コントローラはホストとして動作するため、このままではデバイスになることができません。
-コントローラの動作モードを切り替えるには brain-config というツールを使います。
-詳しい使い方は[brain-config](/linux/brain-config)のページで確認してください。
+コントローラの動作モードを切り替える方法には、brain-config というツールを使う方法と手動でデバイスツリーを書き換える方法があります。
 
 
-# 手動での変更
+## 方法A. brain-config で変更する
+
+`brain-config` による動作モードの切り替え方法については [brain-config](/linux/brain-config) のページを参照してください。
+
+
+## 方法B. 手動で変更する
 
 手動で変更するには、以下の手順に従ってください。
 
@@ -37,16 +41,16 @@ excerpt: PC と USB ケーブル1本で接続できる便利な仕組みとそ�
 
 2. 元のdtsをバックアップします
 
-   {機種名の数字}は適宜置き換えてください。（例:PW-SH5→imx28-pwsh5.dtb）
+   `{デバイスツリー名}`の箇所は、[対応機種の表](/beginners/get-started/#対応している機種)でお使いの機種を探して、対応する「デバイスツリー名」列の文字列で置き換えてください。（例:PW-SH5→imx28-pwsh5.dtb）
 
    ```sh
-   sudo cp /boot/imx28-pwsh{機種名の数字}.dtb /boot/imx28-pwsh{機種名の数字}.dtb.orig
+   sudo cp /boot/{デバイスツリー名}.dtb /boot/{デバイスツリー名}.dtb.orig
    ```
 
 3. dtbファイルをテキスト形式に変換します
 
    ```sh
-   dtc -I dtb -O dts /boot/imx28-pwsh{機種名の数字}.dtb > dts 2> /dev/null
+   dtc -I dtb -O dts /boot/{デバイスツリー名}.dtb > dts 2> /dev/null
    ```
 
 4. 設定を書き換えます
@@ -84,7 +88,7 @@ excerpt: PC と USB ケーブル1本で接続できる便利な仕組みとそ�
    ```
 
    ```sh
-   sudo mv dtb /boot/imx28-pwsh{機種名の数字}.dtb
+   sudo mv dtb /boot/{デバイスツリー名}.dtb
    ```
 
 6. SDカードの第1パーティションアンマウントします
@@ -99,28 +103,28 @@ excerpt: PC と USB ケーブル1本で接続できる便利な仕組みとそ�
    sudo reboot
    ```
 
-
-## コピペ用
-
 1〜3の手順をまとめると以下のようになります。
 
 ```sh
 sudo mount /dev/mmcblk1p1 /boot
-sudo cp /boot/imx28-pwsh{機種名の数字}.dtb /boot/imx28-pwsh{機種名の数字}.dtb.orig
-dtc -I dtb -O dts /boot/imx28-pwsh{機種名の数字}.dtb > dts 2> /dev/null
+sudo cp /boot/{デバイスツリー名}.dtb /boot/{デバイスツリー名}.dtb.orig
+dtc -I dtb -O dts /boot/{デバイスツリー名}.dtb > dts 2> /dev/null
 ```
 
 5〜7の手順をまとめると以下のようになります。
 
 ```sh
 dtc -I dts -O dtb dts > dtb 2> /dev/null
-sudo mv dtb /boot/imx28-pwsh{機種名の数字}.dtb
+sudo mv dtb /boot/{デバイスツリー名}.dtb
 sudo umount /boot
 sudo reboot
 ```
 
 
 # Brain に Ethernet Gadget を喋らせる
+
+sysfs のファイル操作により Ethernet Gadget を有効化します。
+Brainux バージョン 2023-07-29-024604 以降では有効化処理が起動時に自動で実行されます。もし手動で有効化したい場合は以下の手順を参照してください。
 
 1. 以下のスクリプトを vi や nano でホームディレクトリに保存します
 


### PR DESCRIPTION
 - 機種名からデバイスツリーの名前を判定する方法を「初めての方へ」にある機種の表を見る方法に改めました
 - デバイスツリーの書き換え diff を実際に即したものにアップデートしました
 - sudo を追記しました
 - 最新の Brainux では自動で Ethernet Gadget が生える旨を追記しました