### PR TITLE
Use EditorConfig to recommend LF for markdown and HTML EOL

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,3 +3,7 @@ root = true
 [*.html]
 charset = utf-8
 indent_size = 2
+end_of_line = lf
+
+[*.md]
+end_of_line = lf


### PR DESCRIPTION
```
git config --global core.autocrlf input
```

が行われていない環境で事故防止に、念のため強制力はないが editorconfig 上で推奨する