### PR TITLE
Rename: `Brain Hackers Wiki` -> `Brainux Wiki`

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@
 # you will see them accessed via {{ site.title }}, {{ site.email }}, and so on.
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
-title: Brain Hackers Wiki
+title: Brainux Wiki
 author: Brain Hackers
 description: >- # this means to ignore newlines until "baseurl:"
   The Wiki of Brain Hackers

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -3,7 +3,7 @@ permalink: /about/
 title: "About"
 ---
 
-Brain Hackers Wiki は、電子辞書ハックを愛するメンバーが集う Brain Hackers が運営するサイトです。
+Brainux Wiki は、電子辞書ハックを愛するメンバーが集う Brain Hackers が運営するサイトです。
 電子辞書で Linux を動かすチュートリアルや有用な知見がどなたでも簡単に手に入ることを目指しています。
 
 開発に関するより詳細な情報や会話については Discord やその他の箇所にあります。詳しくは [GitHub Org](https://github.com/brain-hackers/README) のページから参照してください。

--- a/prh_rules/wiki.yml
+++ b/prh_rules/wiki.yml
@@ -1,4 +1,4 @@
-# Rules for Brain Hackers Wiki
+# Rules for Brainux Wiki
 # Based on WEB+DB PRESS prh rules
 meta:
   reviewer:


### PR DESCRIPTION
全文検索しました（置換は手作業）